### PR TITLE
feat(brain): track tier-1 registries and validate dependencies

### DIFF
--- a/scripts/brain/knowledge-layer.ts
+++ b/scripts/brain/knowledge-layer.ts
@@ -37,6 +37,30 @@ export interface MCP {
   supports_skills?: string[];
 }
 
+interface Tool {
+  id: string;
+  name: string;
+  description?: string;
+  category?: string;
+  [key: string]: any;
+}
+
+interface Component {
+  id: string;
+  name: string;
+  description?: string;
+  category?: string;
+  [key: string]: any;
+}
+
+interface Integration {
+  id: string;
+  name: string;
+  description?: string;
+  category?: string;
+  [key: string]: any;
+}
+
 interface SkillRegistry {
   version: string;
   last_updated: string;
@@ -53,6 +77,31 @@ interface MCPRegistry {
   description: string;
   mcps: MCP[];
   categories: any[];
+}
+
+interface ToolRegistry {
+  version: string;
+  last_updated: string;
+  description: string;
+  tools: Tool[];
+  total_tools?: number;
+  total_scripts?: number;
+}
+
+interface ComponentRegistry {
+  version: string;
+  last_updated: string;
+  description: string;
+  components: Component[];
+  total_components?: number;
+}
+
+interface IntegrationRegistry {
+  version: string;
+  last_updated: string;
+  description: string;
+  integrations: Integration[];
+  total_integrations?: number;
 }
 
 interface RelationshipMapping {
@@ -72,6 +121,9 @@ export class KnowledgeLayer {
   private rootPath: string;
   private skillRegistry: SkillRegistry | null = null;
   private mcpRegistry: MCPRegistry | null = null;
+  private toolRegistry: ToolRegistry | null = null;
+  private componentRegistry: ComponentRegistry | null = null;
+  private integrationRegistry: IntegrationRegistry | null = null;
   private relationshipMapping: RelationshipMapping | null = null;
 
   constructor(rootPath: string) {
@@ -91,6 +143,18 @@ export class KnowledgeLayer {
     // Load MCP registry
     const mcpRegistryPath = path.join(metaPath, 'mcp-registry.json');
     this.mcpRegistry = JSON.parse(fs.readFileSync(mcpRegistryPath, 'utf-8'));
+
+    // Load tool registry
+    const toolRegistryPath = path.join(metaPath, 'tool-registry.json');
+    this.toolRegistry = JSON.parse(fs.readFileSync(toolRegistryPath, 'utf-8'));
+
+    // Load component registry
+    const componentRegistryPath = path.join(metaPath, 'component-registry.json');
+    this.componentRegistry = JSON.parse(fs.readFileSync(componentRegistryPath, 'utf-8'));
+
+    // Load integration registry
+    const integrationRegistryPath = path.join(metaPath, 'integration-registry.json');
+    this.integrationRegistry = JSON.parse(fs.readFileSync(integrationRegistryPath, 'utf-8'));
 
     // Load relationship mapping
     const relationshipPath = path.join(metaPath, 'relationship-mapping.json');
@@ -216,6 +280,75 @@ export class KnowledgeLayer {
   }
 
   // ============================================
+  // TOOL QUERIES
+  // ============================================
+
+  /**
+   * Get total count of tools
+   */
+  getToolCount(): number {
+    if (!this.toolRegistry) throw new Error('Registries not loaded');
+    return this.toolRegistry.tools.length;
+  }
+
+  /**
+   * Get specific tool by ID or name
+   */
+  getTool(idOrName: string): Tool | null {
+    if (!this.toolRegistry) throw new Error('Registries not loaded');
+    const lowerQuery = idOrName.toLowerCase();
+    return this.toolRegistry.tools.find(tool =>
+      tool.id === idOrName || tool.name?.toLowerCase() === lowerQuery
+    ) || null;
+  }
+
+  // ============================================
+  // COMPONENT QUERIES
+  // ============================================
+
+  /**
+   * Get total count of components
+   */
+  getComponentCount(): number {
+    if (!this.componentRegistry) throw new Error('Registries not loaded');
+    return this.componentRegistry.components.length;
+  }
+
+  /**
+   * Get specific component by ID or name
+   */
+  getComponent(idOrName: string): Component | null {
+    if (!this.componentRegistry) throw new Error('Registries not loaded');
+    const lowerQuery = idOrName.toLowerCase();
+    return this.componentRegistry.components.find(component =>
+      component.id === idOrName || component.name?.toLowerCase() === lowerQuery
+    ) || null;
+  }
+
+  // ============================================
+  // INTEGRATION QUERIES
+  // ============================================
+
+  /**
+   * Get total count of integrations
+   */
+  getIntegrationCount(): number {
+    if (!this.integrationRegistry) throw new Error('Registries not loaded');
+    return this.integrationRegistry.integrations.length;
+  }
+
+  /**
+   * Get specific integration by ID or name
+   */
+  getIntegration(idOrName: string): Integration | null {
+    if (!this.integrationRegistry) throw new Error('Registries not loaded');
+    const lowerQuery = idOrName.toLowerCase();
+    return this.integrationRegistry.integrations.find(integration =>
+      integration.id === idOrName || integration.name?.toLowerCase() === lowerQuery
+    ) || null;
+  }
+
+  // ============================================
   // RELATIONSHIP QUERIES
   // ============================================
 
@@ -315,14 +448,27 @@ export class KnowledgeLayer {
     relationshipVersion: string;
     lastUpdated: string;
   } {
-    if (!this.skillRegistry || !this.mcpRegistry || !this.relationshipMapping) {
+    if (
+      !this.skillRegistry ||
+      !this.mcpRegistry ||
+      !this.toolRegistry ||
+      !this.componentRegistry ||
+      !this.integrationRegistry ||
+      !this.relationshipMapping
+    ) {
       throw new Error('Registries not loaded');
     }
 
+    const skillCount = this.getSkillCount();
+    const mcpCount = this.getMCPCount();
+    const toolCount = this.getToolCount();
+    const componentCount = this.getComponentCount();
+    const integrationCount = this.getIntegrationCount();
+
     return {
-      skills: this.getSkillCount(),
-      mcps: this.getMCPCount(),
-      totalResources: this.getSkillCount() + this.getMCPCount() + 13 + 9 + 6, // + components + tools + integrations
+      skills: skillCount,
+      mcps: mcpCount,
+      totalResources: skillCount + mcpCount + toolCount + componentCount + integrationCount,
       skillRegistryVersion: this.skillRegistry.version,
       mcpRegistryVersion: this.mcpRegistry.version,
       relationshipVersion: this.relationshipMapping.version,
@@ -347,8 +493,26 @@ export class KnowledgeLayer {
   } {
     const errors: string[] = [];
 
-    if (!this.skillRegistry || !this.mcpRegistry || !this.relationshipMapping) {
-      errors.push('Registries not loaded');
+    if (!this.skillRegistry) {
+      errors.push('Skill registry not loaded');
+    }
+    if (!this.mcpRegistry) {
+      errors.push('MCP registry not loaded');
+    }
+    if (!this.toolRegistry) {
+      errors.push('Tool registry not loaded');
+    }
+    if (!this.componentRegistry) {
+      errors.push('Component registry not loaded');
+    }
+    if (!this.integrationRegistry) {
+      errors.push('Integration registry not loaded');
+    }
+    if (!this.relationshipMapping) {
+      errors.push('Relationship mapping not loaded');
+    }
+
+    if (errors.length > 0) {
       return { valid: false, errors };
     }
 
@@ -372,7 +536,25 @@ export class KnowledgeLayer {
     for (const [skillName, deps] of Object.entries(this.relationshipMapping.skills)) {
       for (const mcpName of deps.required_mcps) {
         if (!this.getMCP(mcpName)) {
-          errors.push(`Required MCP '${mcpName}' for skill '${skillName}' not found`);
+          errors.push(`Required MCP '${mcpName}' for skill '${skillName}' not found in MCP registry`);
+        }
+      }
+
+      for (const toolName of deps.required_tools) {
+        if (!this.getTool(toolName)) {
+          errors.push(`Required tool '${toolName}' for skill '${skillName}' not found in tool registry`);
+        }
+      }
+
+      for (const componentName of deps.required_components) {
+        if (!this.getComponent(componentName)) {
+          errors.push(`Required component '${componentName}' for skill '${skillName}' not found in component registry`);
+        }
+      }
+
+      for (const integrationName of deps.required_integrations) {
+        if (!this.getIntegration(integrationName)) {
+          errors.push(`Required integration '${integrationName}' for skill '${skillName}' not found in integration registry`);
         }
       }
     }

--- a/scripts/brain/tests/knowledge-layer.test.ts
+++ b/scripts/brain/tests/knowledge-layer.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import os from 'os';
+import { KnowledgeLayer } from '../knowledge-layer';
+
+interface Registries {
+  skillRegistry: any;
+  mcpRegistry: any;
+  toolRegistry: any;
+  componentRegistry: any;
+  integrationRegistry: any;
+  relationshipMapping: any;
+}
+
+function createBaseRegistries(): Registries {
+  return {
+    skillRegistry: {
+      version: '1.0.0',
+      last_updated: '2024-01-01',
+      description: 'Test skill registry',
+      skills: [
+        {
+          name: 'demo-skill',
+          description: 'Demo skill',
+          triggers: ['demo'],
+          tags: ['demo'],
+          category: 'demo',
+          difficulty: 'beginner',
+          estimated_time: '5m',
+          path: 'SKILLS/demo-skill.md',
+          status: 'active',
+          prerequisites: [],
+          related_skills: [],
+          frameworks: [],
+          languages: []
+        },
+        {
+          name: 'second-skill',
+          description: 'Second skill',
+          triggers: ['second'],
+          tags: ['second'],
+          category: 'demo',
+          difficulty: 'intermediate',
+          estimated_time: '10m',
+          path: 'SKILLS/second-skill.md',
+          status: 'active',
+          prerequisites: [],
+          related_skills: [],
+          frameworks: [],
+          languages: []
+        }
+      ],
+      categories: [],
+      difficulty_levels: [],
+      usage_notes: {}
+    },
+    mcpRegistry: {
+      version: '1.0.0',
+      last_updated: '2024-01-01',
+      description: 'Test MCP registry',
+      mcps: [
+        {
+          id: 'demo-mcp',
+          name: 'Demo MCP',
+          description: 'Demo MCP',
+          category: 'demo',
+          status: 'active',
+          path: 'MCP/demo-mcp.md'
+        }
+      ],
+      categories: []
+    },
+    toolRegistry: {
+      version: '1.0.0',
+      last_updated: '2024-01-01',
+      description: 'Test tool registry',
+      tools: [
+        { id: 'tool-one', name: 'Tool One' },
+        { id: 'tool-two', name: 'Tool Two' },
+        { id: 'tool-three', name: 'Tool Three' }
+      ],
+      total_tools: 3,
+      total_scripts: 0
+    },
+    componentRegistry: {
+      version: '1.0.0',
+      last_updated: '2024-01-01',
+      description: 'Test component registry',
+      components: [
+        { id: 'component-alpha', name: 'Component Alpha' }
+      ],
+      total_components: 1
+    },
+    integrationRegistry: {
+      version: '1.0.0',
+      last_updated: '2024-01-01',
+      description: 'Test integration registry',
+      integrations: [
+        { id: 'integration-alpha', name: 'Integration Alpha' },
+        { id: 'integration-beta', name: 'Integration Beta' }
+      ],
+      total_integrations: 2
+    },
+    relationshipMapping: {
+      version: '1.0.0',
+      last_updated: '2024-01-01',
+      description: 'Test relationship mapping',
+      skills: {
+        'demo-skill': {
+          required_mcps: ['demo-mcp'],
+          required_tools: ['tool-one'],
+          required_components: ['component-alpha'],
+          required_integrations: ['integration-alpha'],
+          supporting_scripts: []
+        },
+        'second-skill': {
+          required_mcps: ['demo-mcp'],
+          required_tools: ['tool-two'],
+          required_components: [],
+          required_integrations: ['integration-beta'],
+          supporting_scripts: []
+        }
+      }
+    }
+  };
+}
+
+function createTestEnvironment(customize?: (registries: Registries) => void) {
+  const registries = createBaseRegistries();
+  customize?.(registries);
+
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'knowledge-layer-'));
+  const metaDir = path.join(root, 'META');
+  fs.mkdirSync(metaDir);
+
+  const files: Record<string, any> = {
+    'skill-registry.json': registries.skillRegistry,
+    'mcp-registry.json': registries.mcpRegistry,
+    'tool-registry.json': registries.toolRegistry,
+    'component-registry.json': registries.componentRegistry,
+    'integration-registry.json': registries.integrationRegistry,
+    'relationship-mapping.json': registries.relationshipMapping
+  };
+
+  for (const [filename, content] of Object.entries(files)) {
+    fs.writeFileSync(path.join(metaDir, filename), JSON.stringify(content, null, 2), 'utf-8');
+  }
+
+  return { root, registries };
+}
+
+describe('KnowledgeLayer registry integration', () => {
+  it('calculates total resources using dynamic registry counts', async () => {
+    const { root } = createTestEnvironment();
+    const layer = new KnowledgeLayer(root);
+
+    await layer.loadRegistries();
+    const initialState = layer.getRepositoryState();
+    expect(initialState.skills).toBe(2);
+    expect(initialState.mcps).toBe(1);
+    expect(initialState.totalResources).toBe(9);
+
+    const toolRegistryPath = path.join(root, 'META', 'tool-registry.json');
+    const toolRegistry = JSON.parse(fs.readFileSync(toolRegistryPath, 'utf-8'));
+    toolRegistry.tools.push({ id: 'tool-four', name: 'Tool Four' });
+    fs.writeFileSync(toolRegistryPath, JSON.stringify(toolRegistry, null, 2), 'utf-8');
+
+    await layer.loadRegistries();
+    const updatedState = layer.getRepositoryState();
+    expect(updatedState.totalResources).toBe(10);
+  });
+
+  it('fails validation when required resources are missing', async () => {
+    const { root } = createTestEnvironment(registries => {
+      registries.relationshipMapping.skills['demo-skill'].required_tools.push('missing-tool');
+      registries.relationshipMapping.skills['demo-skill'].required_components.push('missing-component');
+      registries.relationshipMapping.skills['demo-skill'].required_integrations.push('missing-integration');
+    });
+
+    const layer = new KnowledgeLayer(root);
+    await layer.loadRegistries();
+
+    const validation = layer.validateRegistries();
+    expect(validation.valid).toBe(false);
+    expect(validation.errors).toContain("Required tool 'missing-tool' for skill 'demo-skill' not found in tool registry");
+    expect(validation.errors).toContain("Required component 'missing-component' for skill 'demo-skill' not found in component registry");
+    expect(validation.errors).toContain("Required integration 'missing-integration' for skill 'demo-skill' not found in integration registry");
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -45,7 +45,8 @@ export default defineConfig({
     // Test patterns
     include: [
       'tests/**/*.test.ts',
-      'tests/**/*.spec.ts'
+      'tests/**/*.spec.ts',
+      'scripts/brain/**/*.test.ts'
     ],
 
     // Timeout for tests


### PR DESCRIPTION
## Summary
- load tool, component, and integration registries in the knowledge layer and expose helper queries
- compute repository totals from actual registry counts and validate dependency links across all tier-1 resources
- add vitest coverage to ensure totals update with registry changes and validation flags missing resources

## Testing
- npm test -- --run scripts/brain/tests/knowledge-layer.test.ts

------
https://chatgpt.com/codex/tasks/task_b_69010e2c78ec833381990a9d9d42acdc