### PR TITLE
feat: expand brain registry coverage and fix MCP warnings

### DIFF
--- a/scripts/brain/brain-core.ts
+++ b/scripts/brain/brain-core.ts
@@ -81,9 +81,15 @@ export class RepositoryBrain {
     state: {
       skills: number;
       mcps: number;
+      components: number;
+      tools: number;
+      integrations: number;
       totalResources: number;
       skillRegistryVersion: string;
       mcpRegistryVersion: string;
+      componentRegistryVersion: string;
+      toolRegistryVersion: string;
+      integrationRegistryVersion: string;
       relationshipVersion: string;
       lastUpdated: string;
     };

--- a/scripts/brain/brain.ts
+++ b/scripts/brain/brain.ts
@@ -192,12 +192,18 @@ async function commandStatus(brain: RepositoryBrain): Promise<void> {
   console.log(colorize('State:', 'bright'));
   console.log(`  Skills: ${colorize(status.state.skills.toString(), 'cyan')}`);
   console.log(`  MCPs: ${colorize(status.state.mcps.toString(), 'cyan')}`);
+  console.log(`  Components: ${colorize(status.state.components.toString(), 'cyan')}`);
+  console.log(`  Tools: ${colorize(status.state.tools.toString(), 'cyan')}`);
+  console.log(`  Integrations: ${colorize(status.state.integrations.toString(), 'cyan')}`);
   console.log(`  Total Resources: ${colorize(status.state.totalResources.toString(), 'cyan')}`);
   console.log(`  Last Updated: ${colorize(status.state.lastUpdated, 'dim')}`);
 
   console.log(`\n${colorize('Versions:', 'bright')}`);
   console.log(`  Skill Registry: ${status.state.skillRegistryVersion}`);
   console.log(`  MCP Registry: ${status.state.mcpRegistryVersion}`);
+  console.log(`  Component Registry: ${status.state.componentRegistryVersion}`);
+  console.log(`  Tool Registry: ${status.state.toolRegistryVersion}`);
+  console.log(`  Integration Registry: ${status.state.integrationRegistryVersion}`);
   console.log(`  Relationships: ${status.state.relationshipVersion}`);
 
   console.log(`\n${colorize('Health:', 'bright')}`);

--- a/scripts/brain/knowledge-layer.ts
+++ b/scripts/brain/knowledge-layer.ts
@@ -55,6 +55,59 @@ interface MCPRegistry {
   categories: any[];
 }
 
+export interface ComponentResource {
+  id: string;
+  name: string;
+  category: string;
+  description: string;
+  path: string;
+  status: string;
+  language?: string;
+  framework?: string;
+}
+
+interface ComponentRegistry {
+  version: string;
+  last_updated: string;
+  description: string;
+  components: ComponentResource[];
+}
+
+export interface ToolResource {
+  id: string;
+  name: string;
+  category: string;
+  description: string;
+  path: string;
+  status: string;
+  language?: string;
+  framework?: string;
+}
+
+interface ToolRegistry {
+  version: string;
+  last_updated: string;
+  description: string;
+  tools: ToolResource[];
+}
+
+export interface IntegrationResource {
+  id: string;
+  name: string;
+  category: string;
+  description: string;
+  path: string;
+  status: string;
+  authentication?: string;
+}
+
+interface IntegrationRegistry {
+  version: string;
+  last_updated: string;
+  description: string;
+  integrations: IntegrationResource[];
+}
+
 interface RelationshipMapping {
   version: string;
   last_updated: string;
@@ -72,6 +125,9 @@ export class KnowledgeLayer {
   private rootPath: string;
   private skillRegistry: SkillRegistry | null = null;
   private mcpRegistry: MCPRegistry | null = null;
+  private componentRegistry: ComponentRegistry | null = null;
+  private toolRegistry: ToolRegistry | null = null;
+  private integrationRegistry: IntegrationRegistry | null = null;
   private relationshipMapping: RelationshipMapping | null = null;
 
   constructor(rootPath: string) {
@@ -91,6 +147,18 @@ export class KnowledgeLayer {
     // Load MCP registry
     const mcpRegistryPath = path.join(metaPath, 'mcp-registry.json');
     this.mcpRegistry = JSON.parse(fs.readFileSync(mcpRegistryPath, 'utf-8'));
+
+    // Load component registry
+    const componentRegistryPath = path.join(metaPath, 'component-registry.json');
+    this.componentRegistry = JSON.parse(fs.readFileSync(componentRegistryPath, 'utf-8'));
+
+    // Load tool registry
+    const toolRegistryPath = path.join(metaPath, 'tool-registry.json');
+    this.toolRegistry = JSON.parse(fs.readFileSync(toolRegistryPath, 'utf-8'));
+
+    // Load integration registry
+    const integrationRegistryPath = path.join(metaPath, 'integration-registry.json');
+    this.integrationRegistry = JSON.parse(fs.readFileSync(integrationRegistryPath, 'utf-8'));
 
     // Load relationship mapping
     const relationshipPath = path.join(metaPath, 'relationship-mapping.json');
@@ -203,6 +271,80 @@ export class KnowledgeLayer {
     return this.mcpRegistry.mcps;
   }
 
+  // ============================================
+  // COMPONENT QUERIES
+  // ============================================
+
+  getComponentCount(): number {
+    if (!this.componentRegistry) throw new Error('Registries not loaded');
+    return this.componentRegistry.components.length;
+  }
+
+  getComponent(idOrName: string): ComponentResource | null {
+    if (!this.componentRegistry) throw new Error('Registries not loaded');
+    const byId = this.componentRegistry.components.find(component => component.id === idOrName);
+    if (byId) {
+      return byId;
+    }
+    const lower = idOrName.toLowerCase();
+    return this.componentRegistry.components.find(component => component.name.toLowerCase() === lower) || null;
+  }
+
+  getAllComponents(): ComponentResource[] {
+    if (!this.componentRegistry) throw new Error('Registries not loaded');
+    return this.componentRegistry.components;
+  }
+
+  // ============================================
+  // TOOL QUERIES
+  // ============================================
+
+  getToolCount(): number {
+    if (!this.toolRegistry) throw new Error('Registries not loaded');
+    return this.toolRegistry.tools.length;
+  }
+
+  getTool(idOrName: string): ToolResource | null {
+    if (!this.toolRegistry) throw new Error('Registries not loaded');
+    const byId = this.toolRegistry.tools.find(tool => tool.id === idOrName);
+    if (byId) {
+      return byId;
+    }
+    const lower = idOrName.toLowerCase();
+    return this.toolRegistry.tools.find(tool => tool.name.toLowerCase() === lower) || null;
+  }
+
+  getAllTools(): ToolResource[] {
+    if (!this.toolRegistry) throw new Error('Registries not loaded');
+    return this.toolRegistry.tools;
+  }
+
+  // ============================================
+  // INTEGRATION QUERIES
+  // ============================================
+
+  getIntegrationCount(): number {
+    if (!this.integrationRegistry) throw new Error('Registries not loaded');
+    return this.integrationRegistry.integrations.length;
+  }
+
+  getIntegration(idOrName: string): IntegrationResource | null {
+    if (!this.integrationRegistry) throw new Error('Registries not loaded');
+    const byId = this.integrationRegistry.integrations.find(integration => integration.id === idOrName);
+    if (byId) {
+      return byId;
+    }
+    const lower = idOrName.toLowerCase();
+    return (
+      this.integrationRegistry.integrations.find(integration => integration.name.toLowerCase() === lower) || null
+    );
+  }
+
+  getAllIntegrations(): IntegrationResource[] {
+    if (!this.integrationRegistry) throw new Error('Registries not loaded');
+    return this.integrationRegistry.integrations;
+  }
+
   /**
    * Search MCPs by keyword
    */
@@ -309,22 +451,47 @@ export class KnowledgeLayer {
   getRepositoryState(): {
     skills: number;
     mcps: number;
+    components: number;
+    tools: number;
+    integrations: number;
     totalResources: number;
     skillRegistryVersion: string;
     mcpRegistryVersion: string;
+    componentRegistryVersion: string;
+    toolRegistryVersion: string;
+    integrationRegistryVersion: string;
     relationshipVersion: string;
     lastUpdated: string;
   } {
-    if (!this.skillRegistry || !this.mcpRegistry || !this.relationshipMapping) {
+    if (
+      !this.skillRegistry ||
+      !this.mcpRegistry ||
+      !this.componentRegistry ||
+      !this.toolRegistry ||
+      !this.integrationRegistry ||
+      !this.relationshipMapping
+    ) {
       throw new Error('Registries not loaded');
     }
 
+    const skills = this.getSkillCount();
+    const mcps = this.getMCPCount();
+    const components = this.getComponentCount();
+    const tools = this.getToolCount();
+    const integrations = this.getIntegrationCount();
+
     return {
-      skills: this.getSkillCount(),
-      mcps: this.getMCPCount(),
-      totalResources: this.getSkillCount() + this.getMCPCount() + 13 + 9 + 6, // + components + tools + integrations
+      skills,
+      mcps,
+      components,
+      tools,
+      integrations,
+      totalResources: skills + mcps + components + tools + integrations,
       skillRegistryVersion: this.skillRegistry.version,
       mcpRegistryVersion: this.mcpRegistry.version,
+      componentRegistryVersion: this.componentRegistry.version,
+      toolRegistryVersion: this.toolRegistry.version,
+      integrationRegistryVersion: this.integrationRegistry.version,
       relationshipVersion: this.relationshipMapping.version,
       lastUpdated: this.skillRegistry.last_updated
     };
@@ -347,7 +514,14 @@ export class KnowledgeLayer {
   } {
     const errors: string[] = [];
 
-    if (!this.skillRegistry || !this.mcpRegistry || !this.relationshipMapping) {
+    if (
+      !this.skillRegistry ||
+      !this.mcpRegistry ||
+      !this.componentRegistry ||
+      !this.toolRegistry ||
+      !this.integrationRegistry ||
+      !this.relationshipMapping
+    ) {
       errors.push('Registries not loaded');
       return { valid: false, errors };
     }
@@ -373,6 +547,24 @@ export class KnowledgeLayer {
       for (const mcpName of deps.required_mcps) {
         if (!this.getMCP(mcpName)) {
           errors.push(`Required MCP '${mcpName}' for skill '${skillName}' not found`);
+        }
+      }
+
+      for (const toolId of deps.required_tools || []) {
+        if (!this.getTool(toolId)) {
+          errors.push(`Required tool '${toolId}' for skill '${skillName}' not found`);
+        }
+      }
+
+      for (const componentId of deps.required_components || []) {
+        if (!this.getComponent(componentId)) {
+          errors.push(`Required component '${componentId}' for skill '${skillName}' not found`);
+        }
+      }
+
+      for (const integrationId of deps.required_integrations || []) {
+        if (!this.getIntegration(integrationId)) {
+          errors.push(`Required integration '${integrationId}' for skill '${skillName}' not found`);
         }
       }
     }

--- a/scripts/brain/mcp-integrator.ts
+++ b/scripts/brain/mcp-integrator.ts
@@ -42,10 +42,24 @@ export class MCPIntegrator {
     required_tools: string[];
     required_integrations: string[];
   }>;
+  private mcpIdSet: Set<string>;
+  private mcpById: Map<string, MCP>;
+  private mcpNameMap: Map<string, MCP>;
+  private mcpLabelMap: Map<string, string>;
 
   constructor(mcps: MCP[], relationshipMapping: RelationshipMapping) {
     this.mcps = mcps;
     this.relationshipMapping = relationshipMapping.skills || {};
+    this.mcpById = new Map(mcps.map(m => [m.id, m]));
+    this.mcpIdSet = new Set(this.mcpById.keys());
+    this.mcpNameMap = new Map(mcps.map(m => [m.name.toLowerCase(), m]));
+    this.mcpLabelMap = new Map();
+
+    for (const mcp of mcps) {
+      const label = `${mcp.name} (${mcp.id})`;
+      this.mcpLabelMap.set(mcp.id, label);
+      this.mcpLabelMap.set(mcp.name.toLowerCase(), label);
+    }
   }
 
   /**
@@ -223,9 +237,8 @@ export class MCPIntegrator {
 
     // Check if any MCPs are missing
     for (const mcp of mcps) {
-      const mcpExists = this.mcps.some(m => m.name === mcp);
-      if (!mcpExists) {
-        warnings.push(`MCP '${mcp}' is required but not yet implemented`);
+      if (!this.hasMCP(mcp)) {
+        warnings.push(`MCP '${this.getMCPLabel(mcp)}' is required but not yet implemented`);
       }
     }
 
@@ -254,7 +267,7 @@ export class MCPIntegrator {
    * Get MCP status (official, community, custom)
    */
   getMCPStatus(mcpName: string): 'official' | 'community' | 'custom' | 'not-found' {
-    const mcp = this.mcps.find(m => m.name === mcpName);
+    const mcp = this.resolveMCP(mcpName);
     if (!mcp) return 'not-found';
 
     // Check status field
@@ -298,7 +311,7 @@ export class MCPIntegrator {
     const steps: string[] = [];
 
     for (const mcpName of mcps) {
-      const mcp = this.mcps.find(m => m.name === mcpName);
+      const mcp = this.resolveMCP(mcpName);
       if (!mcp) continue;
 
       // Estimate based on MCP type
@@ -340,14 +353,36 @@ export class MCPIntegrator {
    */
   findSkillsForMCP(mcpName: string): string[] {
     const skills: string[] = [];
+    const resolvedMCP = this.resolveMCP(mcpName);
+    const id = resolvedMCP ? resolvedMCP.id : mcpName;
 
     for (const [skill, deps] of Object.entries(this.relationshipMapping)) {
-      if (deps.required_mcps && deps.required_mcps.includes(mcpName)) {
+      if (deps.required_mcps && deps.required_mcps.includes(id)) {
         skills.push(skill);
       }
     }
 
     return skills;
+  }
+
+  private hasMCP(identifier: string): boolean {
+    if (this.mcpIdSet.has(identifier)) {
+      return true;
+    }
+    const byName = this.mcpNameMap.get(identifier.toLowerCase());
+    return Boolean(byName);
+  }
+
+  private getMCPLabel(identifier: string): string {
+    return this.mcpLabelMap.get(identifier) || this.mcpLabelMap.get(identifier.toLowerCase()) || identifier;
+  }
+
+  private resolveMCP(identifier: string): MCP | null {
+    if (this.mcpIdSet.has(identifier)) {
+      return this.mcpById.get(identifier) || null;
+    }
+    const byName = this.mcpNameMap.get(identifier.toLowerCase());
+    return byName || null;
   }
 
   /**

--- a/tests/unit/brain/knowledge-layer.test.ts
+++ b/tests/unit/brain/knowledge-layer.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest'
+import fs from 'fs'
+import path from 'path'
+import os from 'os'
+import { KnowledgeLayer } from '../../../scripts/brain/knowledge-layer'
+
+const metaRelativePath = ['META']
+
+const skillRegistry = {
+  version: '1.0.0',
+  last_updated: '2024-01-01',
+  description: 'Test skills',
+  skills: [
+    {
+      name: 'test-skill',
+      description: 'A skill for testing',
+      triggers: [],
+      tags: [],
+      category: 'testing',
+      difficulty: 'beginner',
+      estimated_time: '5m',
+      path: '/SKILLS/test-skill',
+      status: 'active',
+      prerequisites: [],
+      related_skills: [],
+      frameworks: [],
+      languages: []
+    }
+  ],
+  categories: [],
+  difficulty_levels: [],
+  usage_notes: {}
+}
+
+const mcpRegistry = {
+  version: '1.0.0',
+  last_updated: '2024-01-01',
+  description: 'Test MCPs',
+  mcps: [
+    {
+      id: 'test-mcp',
+      name: 'Test MCP',
+      description: 'Test mcp',
+      category: 'testing',
+      status: 'official',
+      path: '/MCP/test-mcp'
+    }
+  ],
+  categories: []
+}
+
+const componentRegistry = {
+  version: '1.0.0',
+  last_updated: '2024-01-01',
+  description: 'Test components',
+  components: [
+    {
+      id: 'test-component',
+      name: 'Test Component',
+      category: 'testing',
+      description: 'Component description',
+      path: '/COMPONENTS/test-component',
+      status: 'active'
+    }
+  ]
+}
+
+const toolRegistry = {
+  version: '1.0.0',
+  last_updated: '2024-01-01',
+  description: 'Test tools',
+  tools: [
+    {
+      id: 'test-tool',
+      name: 'Test Tool',
+      category: 'testing',
+      description: 'Tool description',
+      path: '/TOOLS/test-tool',
+      status: 'active'
+    }
+  ]
+}
+
+const integrationRegistry = {
+  version: '1.0.0',
+  last_updated: '2024-01-01',
+  description: 'Test integrations',
+  integrations: [
+    {
+      id: 'test-integration',
+      name: 'Test Integration',
+      category: 'testing',
+      description: 'Integration description',
+      path: '/INTEGRATIONS/test-integration',
+      status: 'active'
+    }
+  ]
+}
+
+const relationshipMapping = {
+  version: '1.0.0',
+  last_updated: '2024-01-01',
+  description: 'Test relationships',
+  skills: {
+    'test-skill': {
+      required_mcps: ['test-mcp'],
+      required_tools: ['test-tool'],
+      required_components: ['test-component'],
+      required_integrations: ['test-integration'],
+      supporting_scripts: []
+    }
+  }
+}
+
+const registryFiles: Record<string, unknown> = {
+  'skill-registry.json': skillRegistry,
+  'mcp-registry.json': mcpRegistry,
+  'component-registry.json': componentRegistry,
+  'tool-registry.json': toolRegistry,
+  'integration-registry.json': integrationRegistry,
+  'relationship-mapping.json': relationshipMapping
+}
+
+let tempRoot: string
+
+const writeJson = (filePath: string, data: unknown) => {
+  fs.writeFileSync(filePath, JSON.stringify(data, null, 2), 'utf-8')
+}
+
+const setupRegistries = () => {
+  const metaDir = path.join(tempRoot, ...metaRelativePath)
+  fs.rmSync(metaDir, { recursive: true, force: true })
+  fs.mkdirSync(metaDir, { recursive: true })
+
+  for (const [fileName, data] of Object.entries(registryFiles)) {
+    writeJson(path.join(metaDir, fileName), data)
+  }
+}
+
+const createKnowledgeLayer = async () => {
+  const layer = new KnowledgeLayer(tempRoot)
+  await layer.loadRegistries()
+  return layer
+}
+
+beforeAll(() => {
+  tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'knowledge-layer-'))
+})
+
+beforeEach(() => {
+  setupRegistries()
+})
+
+afterAll(() => {
+  fs.rmSync(tempRoot, { recursive: true, force: true })
+})
+
+const getMetaPath = (fileName: string) => path.join(tempRoot, ...metaRelativePath, fileName)
+
+describe('KnowledgeLayer registry aggregation', () => {
+  it('computes repository totals from live registry counts', async () => {
+    const layer = await createKnowledgeLayer()
+    const state = layer.getRepositoryState()
+
+    expect(state.skills).toBe(1)
+    expect(state.mcps).toBe(1)
+    expect(state.components).toBe(1)
+    expect(state.tools).toBe(1)
+    expect(state.integrations).toBe(1)
+
+    const expectedTotal = state.skills + state.mcps + state.components + state.tools + state.integrations
+    expect(state.totalResources).toBe(expectedTotal)
+
+    const toolRegistryPath = getMetaPath('tool-registry.json')
+    const updatedToolRegistry = JSON.parse(fs.readFileSync(toolRegistryPath, 'utf-8'))
+    updatedToolRegistry.tools.push({
+      id: 'second-tool',
+      name: 'Second Tool',
+      category: 'testing',
+      description: 'Another tool',
+      path: '/TOOLS/second-tool',
+      status: 'active'
+    })
+    writeJson(toolRegistryPath, updatedToolRegistry)
+
+    const updatedLayer = await createKnowledgeLayer()
+    const updatedState = updatedLayer.getRepositoryState()
+
+    expect(updatedState.tools).toBe(2)
+    const updatedExpectedTotal =
+      updatedState.skills +
+      updatedState.mcps +
+      updatedState.components +
+      updatedState.tools +
+      updatedState.integrations
+    expect(updatedState.totalResources).toBe(updatedExpectedTotal)
+  })
+
+  it('validates tier-1 dependencies across tools, components, and integrations', async () => {
+    const layer = await createKnowledgeLayer()
+    expect(layer.validateRegistries().valid).toBe(true)
+
+    const relationshipPath = getMetaPath('relationship-mapping.json')
+    const modifiedRelationships = JSON.parse(fs.readFileSync(relationshipPath, 'utf-8'))
+    modifiedRelationships.skills['test-skill'].required_tools.push('missing-tool')
+    modifiedRelationships.skills['test-skill'].required_components.push('missing-component')
+    modifiedRelationships.skills['test-skill'].required_integrations.push('missing-integration')
+    writeJson(relationshipPath, modifiedRelationships)
+
+    const layerWithMissing = await createKnowledgeLayer()
+    const validation = layerWithMissing.validateRegistries()
+
+    expect(validation.valid).toBe(false)
+    expect(validation.errors).toContain("Required tool 'missing-tool' for skill 'test-skill' not found")
+    expect(validation.errors).toContain("Required component 'missing-component' for skill 'test-skill' not found")
+    expect(validation.errors).toContain("Required integration 'missing-integration' for skill 'test-skill' not found")
+  })
+})

--- a/tests/unit/brain/mcp-integrator.test.ts
+++ b/tests/unit/brain/mcp-integrator.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest'
+
+import { MCPIntegrator } from '../../../scripts/brain/mcp-integrator'
+import type { MCP } from '../../../scripts/brain/knowledge-layer'
+
+const mcps: MCP[] = [
+  {
+    id: 'test-mcp',
+    name: 'Test MCP',
+    description: 'A test MCP',
+    category: 'testing',
+    status: 'official',
+    path: '/MCP/test-mcp'
+  },
+  {
+    id: 'secondary-mcp',
+    name: 'Secondary MCP',
+    description: 'Another MCP',
+    category: 'testing',
+    status: 'community',
+    path: '/MCP/secondary-mcp'
+  }
+]
+
+const baseRelationship = {
+  version: '1.0.0',
+  skills: {
+    'test-skill': {
+      required_mcps: ['test-mcp'],
+      required_tools: [],
+      required_integrations: []
+    }
+  }
+}
+
+describe('MCPIntegrator warnings', () => {
+  const createIntegrator = (relationshipOverrides?: Partial<typeof baseRelationship>) => {
+    const merged = JSON.parse(JSON.stringify(baseRelationship))
+    if (relationshipOverrides?.skills) {
+      merged.skills = relationshipOverrides.skills
+    }
+    return new MCPIntegrator(mcps, merged)
+  }
+
+  it('does not warn when required MCP identifiers exist', () => {
+    const integrator = createIntegrator()
+    const result = integrator.integrate(['test-skill'])
+
+    expect(result.warnings).toEqual([])
+  })
+
+  it('warns when required MCP identifiers are missing', () => {
+    const integrator = createIntegrator({
+      skills: {
+        'test-skill': {
+          required_mcps: ['missing-mcp'],
+          required_tools: [],
+          required_integrations: []
+        }
+      }
+    })
+
+    const result = integrator.integrate(['test-skill'])
+
+    expect(result.warnings).toContain("MCP 'missing-mcp' is required but not yet implemented")
+  })
+
+  it('treats friendly MCP names as existing without triggering warnings', () => {
+    const integrator = createIntegrator({
+      skills: {
+        'test-skill': {
+          required_mcps: ['Test MCP'],
+          required_tools: [],
+          required_integrations: []
+        }
+      }
+    })
+
+    const result = integrator.integrate(['test-skill'])
+
+    expect(result.warnings).toEqual([])
+  })
+})


### PR DESCRIPTION
## Summary
- load component, tool, and integration registries in the knowledge layer and compute totals from real counts
- surface the additional registry data through the brain status output and CLI tooling
- switch MCP integrator warnings to id-based lookups and add unit tests covering the new behaviors

## Testing
- npm test -- --run tests/unit/brain/knowledge-layer.test.ts --run tests/unit/brain/mcp-integrator.test.ts *(fails: vitest not found; dependencies unavailable in environment)*

------
https://chatgpt.com/codex/tasks/task_b_6901096089c08333ae16e0b7c4bbac5a